### PR TITLE
Add multi-architecture build support (x86_64 and ARM64)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,12 +54,19 @@ jobs:
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.snapcraft_token }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload RPM to GitHub Releases
+      - name: Build RPM packages (x86_64 and arm64)
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          bash build-rpm.sh
+      - name: Upload RPM packages to GitHub Releases
         if: startsWith(matrix.os, 'ubuntu')
         run: |
           gh release upload "${{ steps.release_tag.outputs.value }}" dist/*.rpm --repo "${{ github.repository }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload to Gemfury
+      - name: Upload x64 deb to Gemfury
         if: startsWith(matrix.os, 'ubuntu')
         run: curl -F package=@dist/caprine_${{ steps.release_tag.outputs.value }}_amd64.deb https://${{ secrets.gemfury_token }}@push.fury.io/lefterisgar/
+      - name: Upload ARM64 deb to Gemfury
+        if: startsWith(matrix.os, 'ubuntu')
+        run: curl -F package=@dist/caprine_${{ steps.release_tag.outputs.value }}_arm64.deb https://${{ secrets.gemfury_token }}@push.fury.io/lefterisgar/

--- a/build-rpm.sh
+++ b/build-rpm.sh
@@ -78,28 +78,28 @@ Caprine is an unofficial and privacy focused Facebook Messenger desktop app.
 
 %install
 mkdir -p %{buildroot}/opt/Caprine
-cp -r $DIST_DIR/* %{buildroot}/opt/Caprine/
+cp -r "$DIST_DIR"/* %{buildroot}/opt/Caprine/
 
 mkdir -p %{buildroot}/usr/share/icons/hicolor/16x16/apps
-install -m 644 $PROJECT_DIR/build/icons/16x16.png %{buildroot}/usr/share/icons/hicolor/16x16/apps/caprine.png
+install -m 644 "$PROJECT_DIR"/build/icons/16x16.png %{buildroot}/usr/share/icons/hicolor/16x16/apps/caprine.png
 
 mkdir -p %{buildroot}/usr/share/icons/hicolor/32x32/apps
-install -m 644 $PROJECT_DIR/build/icons/32x32.png %{buildroot}/usr/share/icons/hicolor/32x32/apps/caprine.png
+install -m 644 "$PROJECT_DIR"/build/icons/32x32.png %{buildroot}/usr/share/icons/hicolor/32x32/apps/caprine.png
 
 mkdir -p %{buildroot}/usr/share/icons/hicolor/48x48/apps
-install -m 644 $PROJECT_DIR/build/icons/48x48.png %{buildroot}/usr/share/icons/hicolor/48x48/apps/caprine.png
+install -m 644 "$PROJECT_DIR"/build/icons/48x48.png %{buildroot}/usr/share/icons/hicolor/48x48/apps/caprine.png
 
 mkdir -p %{buildroot}/usr/share/icons/hicolor/64x64/apps
-install -m 644 $PROJECT_DIR/build/icons/64x64.png %{buildroot}/usr/share/icons/hicolor/64x64/apps/caprine.png
+install -m 644 "$PROJECT_DIR"/build/icons/64x64.png %{buildroot}/usr/share/icons/hicolor/64x64/apps/caprine.png
 
 mkdir -p %{buildroot}/usr/share/icons/hicolor/128x128/apps
-install -m 644 $PROJECT_DIR/build/icons/128x128.png %{buildroot}/usr/share/icons/hicolor/128x128/apps/caprine.png
+install -m 644 "$PROJECT_DIR"/build/icons/128x128.png %{buildroot}/usr/share/icons/hicolor/128x128/apps/caprine.png
 
 mkdir -p %{buildroot}/usr/share/icons/hicolor/256x256/apps
-install -m 644 $PROJECT_DIR/build/icons/256x256.png %{buildroot}/usr/share/icons/hicolor/256x256/apps/caprine.png
+install -m 644 "$PROJECT_DIR"/build/icons/256x256.png %{buildroot}/usr/share/icons/hicolor/256x256/apps/caprine.png
 
 mkdir -p %{buildroot}/usr/share/icons/hicolor/512x512/apps
-install -m 644 $PROJECT_DIR/build/icons/512x512.png %{buildroot}/usr/share/icons/hicolor/512x512/apps/caprine.png
+install -m 644 "$PROJECT_DIR"/build/icons/512x512.png %{buildroot}/usr/share/icons/hicolor/512x512/apps/caprine.png
 
 mkdir -p %{buildroot}/usr/share/applications
 cat > %{buildroot}/usr/share/applications/caprine.desktop << 'DESKTOP_EOF'
@@ -128,8 +128,8 @@ EOF
 
 	rpmbuild -bb "$SPEC_FILE" --target "$TARGET_ARCH"
 
-	cp "$HOME/rpmbuild/RPMS/$TARGET_ARCH/caprine-*.rpm" "$PROJECT_DIR/dist/"
-	mv "$PROJECT_DIR/dist/caprine-*.$TARGET_ARCH.rpm" "$PROJECT_DIR/dist/caprine-$VERSION-$ARCH.rpm"
+	cp "$HOME/rpmbuild/RPMS/$TARGET_ARCH"/caprine-*.rpm "$PROJECT_DIR/dist/"
+	mv "$PROJECT_DIR/dist"/caprine-*."$TARGET_ARCH".rpm "$PROJECT_DIR/dist/caprine-$VERSION-$ARCH.rpm"
 	echo "RPM package built successfully: dist/caprine-$VERSION-$ARCH.rpm"
 }
 

--- a/build-rpm.sh
+++ b/build-rpm.sh
@@ -78,11 +78,7 @@ Caprine is an unofficial and privacy focused Facebook Messenger desktop app.
 
 %install
 mkdir -p %{buildroot}/opt/Caprine
-if [ "$ARCH" = "arm64" ]; then
-	cp -r $PROJECT_DIR/dist/linux-arm64-unpacked/* %{buildroot}/opt/Caprine/
-else
-	cp -r $PROJECT_DIR/dist/linux-unpacked/* %{buildroot}/opt/Caprine/
-fi
+cp -r $DIST_DIR/* %{buildroot}/opt/Caprine/
 
 mkdir -p %{buildroot}/usr/share/icons/hicolor/16x16/apps
 install -m 644 $PROJECT_DIR/build/icons/16x16.png %{buildroot}/usr/share/icons/hicolor/16x16/apps/caprine.png
@@ -132,15 +128,9 @@ EOF
 
 	rpmbuild -bb "$SPEC_FILE" --target "$TARGET_ARCH"
 
-	if [ "$ARCH" = "arm64" ]; then
-		cp ~/rpmbuild/RPMS/arm64/caprine-*.rpm "$PROJECT_DIR/dist/"
-		mv "$PROJECT_DIR/dist/caprine-$VERSION-1.arm64.rpm" "$PROJECT_DIR/dist/caprine-$VERSION-arm64.rpm"
-		echo "RPM package built successfully: dist/caprine-$VERSION-arm64.rpm"
-	else
-		cp ~/rpmbuild/RPMS/x86_64/caprine-*.rpm "$PROJECT_DIR/dist/"
-		mv "$PROJECT_DIR/dist/caprine-$VERSION-1.x86_64.rpm" "$PROJECT_DIR/dist/caprine-$VERSION-x86_64.rpm"
-		echo "RPM package built successfully: dist/caprine-$VERSION-x86_64.rpm"
-	fi
+	cp "$HOME/rpmbuild/RPMS/$TARGET_ARCH/caprine-*.rpm" "$PROJECT_DIR/dist/"
+	mv "$PROJECT_DIR/dist/caprine-*.$TARGET_ARCH.rpm" "$PROJECT_DIR/dist/caprine-$VERSION-$ARCH.rpm"
+	echo "RPM package built successfully: dist/caprine-$VERSION-$ARCH.rpm"
 }
 
 # Build RPM(s) for specified architecture/ies

--- a/build-rpm.sh
+++ b/build-rpm.sh
@@ -1,6 +1,25 @@
 #!/bin/bash
 set -e
 
+# Parse architecture argument
+# Default: build both x86_64 and arm64
+# Single arch: --x86_64, x86_64, --arm64, or arm64
+case "${1:-}" in
+	--x86_64|x86_64)
+		ARCHS=("x86_64")
+		;;
+	--arm64|arm64)
+		ARCHS=("arm64")
+		;;
+	--all|"")
+		ARCHS=("x86_64" "arm64")
+		;;
+	*)
+		echo "Error: Unknown architecture '$1'. Use --x86_64, --arm64, or omit for both."
+		exit 1
+		;;
+esac
+
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$SCRIPT_DIR"
@@ -8,7 +27,29 @@ PROJECT_DIR="$SCRIPT_DIR"
 VERSION=$(node -p "require('$PROJECT_DIR/package.json').version")
 SPEC_FILE="/tmp/caprine.spec"
 
-cat > "$SPEC_FILE" << EOF
+# Function to build RPM for a specific architecture
+build_rpm() {
+	local ARCH=$1
+	local DIST_DIR
+
+	if [ "$ARCH" = "arm64" ]; then
+		DIST_DIR="$PROJECT_DIR/dist/linux-arm64-unpacked"
+		TARGET_ARCH="aarch64"
+	else
+		DIST_DIR="$PROJECT_DIR/dist/linux-unpacked"
+		TARGET_ARCH="$ARCH"
+	fi
+
+	# Check if required dist folder exists
+	if [ ! -d "$DIST_DIR" ]; then
+		echo "Error: Required dist folder not found: $DIST_DIR"
+		echo "Please run 'npm run dist:linux' or 'npm run dist:linux -- --$ARCH' first."
+		exit 1
+	fi
+
+	echo "Building RPM for $ARCH..."
+
+	cat > "$SPEC_FILE" << EOF
 Name:           caprine
 Version:        $VERSION
 Release:        1%{?dist}
@@ -27,7 +68,9 @@ Requires:       at-spi2-core
 Requires:       libuuid
 
 %description
-Caprine is an unofficial and privacy focused Facebook Messenger app with many useful features.
+Caprine is an unofficial and privacy focused Facebook Messenger desktop app.
+
+%global __strip /bin/true
 
 %prep
 
@@ -35,7 +78,11 @@ Caprine is an unofficial and privacy focused Facebook Messenger app with many us
 
 %install
 mkdir -p %{buildroot}/opt/Caprine
-cp -r $PROJECT_DIR/dist/linux-unpacked/* %{buildroot}/opt/Caprine/
+if [ "$ARCH" = "arm64" ]; then
+	cp -r $PROJECT_DIR/dist/linux-arm64-unpacked/* %{buildroot}/opt/Caprine/
+else
+	cp -r $PROJECT_DIR/dist/linux-unpacked/* %{buildroot}/opt/Caprine/
+fi
 
 mkdir -p %{buildroot}/usr/share/icons/hicolor/16x16/apps
 install -m 644 $PROJECT_DIR/build/icons/16x16.png %{buildroot}/usr/share/icons/hicolor/16x16/apps/caprine.png
@@ -83,6 +130,20 @@ DESKTOP_EOF
 - Initial package build
 EOF
 
-rpmbuild -bb "$SPEC_FILE"
-cp ~/rpmbuild/RPMS/x86_64/caprine-*.rpm "$PROJECT_DIR/dist/"
-echo "RPM package built successfully: dist/caprine-$VERSION-1.x86_64.rpm"
+	rpmbuild -bb "$SPEC_FILE" --target "$TARGET_ARCH"
+
+	if [ "$ARCH" = "arm64" ]; then
+		cp ~/rpmbuild/RPMS/arm64/caprine-*.rpm "$PROJECT_DIR/dist/"
+		mv "$PROJECT_DIR/dist/caprine-$VERSION-1.arm64.rpm" "$PROJECT_DIR/dist/caprine-$VERSION-arm64.rpm"
+		echo "RPM package built successfully: dist/caprine-$VERSION-arm64.rpm"
+	else
+		cp ~/rpmbuild/RPMS/x86_64/caprine-*.rpm "$PROJECT_DIR/dist/"
+		mv "$PROJECT_DIR/dist/caprine-$VERSION-1.x86_64.rpm" "$PROJECT_DIR/dist/caprine-$VERSION-x86_64.rpm"
+		echo "RPM package built successfully: dist/caprine-$VERSION-x86_64.rpm"
+	fi
+}
+
+# Build RPM(s) for specified architecture/ies
+for arch in "${ARCHS[@]}"; do
+	build_rpm "$arch"
+done

--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
 					]
 				}
 			],
-			"arch": ["x86_64", "aarch64"]
+			"arch": ["x86_64", "arm64"]
 		},
 		"win": {
 			"verifyUpdateCodeSignature": false,

--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
 					]
 				}
 			],
-			"arch": ["x86_64", "arm64"]
+			"arch": ["x64", "arm64"]
 		},
 		"win": {
 			"verifyUpdateCodeSignature": false,

--- a/package.json
+++ b/package.json
@@ -152,13 +152,26 @@
 		},
 		"linux": {
 			"target": [
-				"AppImage",
-				"deb"
+				{
+					"target": "AppImage",
+					"arch": [
+						"x64",
+						"arm64"
+					]
+				},
+				{
+					"target": "deb",
+					"arch": [
+						"x64",
+						"arm64"
+					]
+				}
 			],
 			"icon": "build/icons/",
 			"synopsis": "Elegant Facebook Messenger desktop app",
-			"description": "Caprine is an unofficial and privacy focused Facebook Messenger app with many useful features.",
-			"category": "Network;Chat"
+			"description": "Caprine is an unofficial and privacy focused Facebook Messenger desktop app with many useful features.",
+			"category": "Network;Chat",
+			"artifactName": "${productName}-${version}-${arch}.${ext}"
 		},
 		"snap": {
 			"plugs": [
@@ -176,16 +189,27 @@
 						"stable"
 					]
 				}
-			]
+			],
+			"arch": ["x86_64", "aarch64"]
 		},
 		"win": {
 			"verifyUpdateCodeSignature": false,
-			"icon": "build/icon.png"
+			"icon": "build/icon.png",
+			"target": [
+				{
+					"target": "nsis",
+					"arch": [
+						"x64",
+						"arm64"
+					]
+				}
+			]
 		},
 		"nsis": {
 			"oneClick": false,
 			"perMachine": false,
-			"allowToChangeInstallationDirectory": true
+			"allowToChangeInstallationDirectory": true,
+			"artifactName": "${productName}-${version}-${arch}.${ext}"
 		}
 	},
 	"husky": {


### PR DESCRIPTION
## Summary
Squashed 3 commits into 1 comprehensive commit adding ARM64 support across all platforms.

## Changes
- Update GitHub Actions workflow to build across all platforms (macOS, Windows, Linux)
- Add ARM64 support for Windows (nsis installer)
- Add ARM64 support for Linux (AppImage, deb, RPM, snap)
- Update build-rpm.sh to support building both x86_64 and arm64 architectures
- Configure electron-builder to generate architecture-specific artifacts
