### PR TITLE
Fix notifications on Wayland (Hyprland)

### DIFF
--- a/source/browser/conversation-list.ts
+++ b/source/browser/conversation-list.ts
@@ -308,7 +308,7 @@ async function countUnread(mutationsList: MutationRecord[]): Promise<void> {
 		const bodyText = textOptions[1] ? generateStringFromNode(textOptions[1]) : undefined;
 
 		if (!titleText) {
-		    continue;
+			continue;
 		}
 
 		// Generate conversation ID for notification tracking

--- a/source/browser/conversation-list.ts
+++ b/source/browser/conversation-list.ts
@@ -235,7 +235,7 @@ function generateStringFromNode(element: Element): string | undefined {
 	return cloneElement.textContent ?? undefined;
 }
 
-function countUnread(mutationsList: MutationRecord[]): void {
+async function countUnread(mutationsList: MutationRecord[]): Promise<void> {
 	const alreadyChecked: string[] = [];
 
 	// Check latest mutation first
@@ -300,13 +300,15 @@ function countUnread(mutationsList: MutationRecord[]): void {
 		alreadyChecked.push(href);
 
 		// Get the icon data URI (set by createConversationList via createIcons).
-		const imgUrl = current.querySelector('img')?.dataset.caprineIcon;
-		const textOptions = current.querySelectorAll<HTMLElement>(selectors.conversationSidebarTextSelector);
+		const img = current.querySelector('img') as HTMLElement | null;
+		const imgUrl = img ? await getIcon(img, true) : '';
+
+		const textOptions = current.querySelectorAll(selectors.conversationSidebarTextSelector);
 		const titleText = generateStringFromNode(textOptions[0]);
 		const bodyText = textOptions[1] ? generateStringFromNode(textOptions[1]) : undefined;
 
-		if (!titleText || !imgUrl) {
-			continue;
+		if (!titleText) {
+		    continue;
 		}
 
 		// Generate conversation ID for notification tracking

--- a/source/index.ts
+++ b/source/index.ts
@@ -874,7 +874,7 @@ ipc.answerRenderer(
 			title,
 			body: config.get('notificationMessagePreview') ? body : 'You have a new message',
 			hasReply: true,
-			icon: nativeImage.createFromDataURL(icon),
+			...(icon ? {icon: nativeImage.createFromDataURL(icon)} : {}),
 			silent: silent || is.linux || is.macos,
 		});
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -917,6 +917,7 @@ ipc.answerRenderer(
 		}
 
 		notification.show();
+		mainWindow.focus();
 	},
 );
 


### PR DESCRIPTION
There were 2 issues with notifications on my Wayland compositor (Hyprland):

1. If the icon was missing the notification path was blocked and no notification was generated - this prevented the handler from firing.
2. There was no focus request from Caprine after a notification was sent - this request is useful e.g. in Wayland for giving the compositor an urgency hint.

I only tested the changes on version 2.61.0s, so a further build confirmation might be needed.