### PR TITLE
Fix conversation navigation and toast notification click

### DIFF
--- a/source/browser.ts
+++ b/source/browser.ts
@@ -612,7 +612,13 @@ async function selectConversation(index: number): Promise<void> {
 		return;
 	}
 
-	conversation.querySelector<HTMLElement>('[role="link"]')!.click();
+	const link = conversation.querySelector<HTMLElement>('[role="link"]');
+	if (!link) {
+		console.error('Could not find link element in conversation', index);
+		return;
+	}
+
+	link.click();
 }
 
 function selectedConversationIndex(offset = 0): number {
@@ -1122,11 +1128,20 @@ document.addEventListener('keydown', async event => {
 		return;
 	}
 
+	if (event.key === 'Tab') {
+		event.preventDefault();
+		await (event.shiftKey ? previousConversation() : nextConversation());
+
+		return;
+	}
+
 	if (event.key === ']') {
+		event.preventDefault();
 		await nextConversation();
 	}
 
 	if (event.key === '[') {
+		event.preventDefault();
 		await previousConversation();
 	}
 
@@ -1152,7 +1167,7 @@ window.addEventListener('message', async ({data: {type, data}}) => {
 	}
 });
 
-function showNotification({id, title, body, icon, silent}: NotificationEvent): void {
+function showNotification({id, href, title, body, icon, silent}: NotificationEvent): void {
 	const image = new Image();
 	image.crossOrigin = 'anonymous';
 	image.src = icon;
@@ -1168,6 +1183,7 @@ function showNotification({id, title, body, icon, silent}: NotificationEvent): v
 
 		ipc.callMain('notification', {
 			id,
+			href,
 			title,
 			body,
 			icon: canvas.toDataURL(),
@@ -1218,8 +1234,16 @@ function insertMessageText(text: string, inputField: HTMLElement): void {
 	document.execCommand('insertText', false, text);
 }
 
-ipc.answerMain('notification-callback', (data: unknown) => {
+ipc.answerMain('notification-callback', async (data: any) => {
 	window.postMessage({type: 'notification-callback', data}, '*');
+
+	if (data.href) {
+		await elementReady(selectors.conversationList, {stopOnDomReady: false});
+		const link = document.querySelector<HTMLElement>(
+			`${selectors.conversationList} [role="row"] [role="link"][href="${data.href}"]`,
+		);
+		link?.click();
+	}
 });
 
 ipc.answerMain('notification-reply-callback', async (data: any) => {

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -583,7 +583,7 @@ async function nextConversation(): Promise<void> {
 	const index = selectedConversationIndex(1);
 
 	if (index !== -1) {
-		await selectConversation(index);
+		await selectConversation(index, 1);
 	}
 }
 
@@ -591,7 +591,7 @@ async function previousConversation(): Promise<void> {
 	const index = selectedConversationIndex(-1);
 
 	if (index !== -1) {
-		await selectConversation(index);
+		await selectConversation(index, -1);
 	}
 }
 
@@ -601,24 +601,37 @@ async function jumpToConversation(key: number): Promise<void> {
 }
 
 // Focus on the conversation with the given index
-async function selectConversation(index: number): Promise<void> {
+async function selectConversation(index: number, direction = 0): Promise<void> {
 	await elementReady(selectors.conversationList, {stopOnDomReady: false});
 
 	const rows = document.querySelectorAll<HTMLElement>(`${selectors.conversationList} [role="row"]`);
-	const conversation = rows[index];
+	const totalRows = rows.length;
 
-	if (!conversation) {
-		console.error('Could not find conversation', index);
+	if (totalRows === 0) {
 		return;
 	}
 
-	const link = conversation.querySelector<HTMLElement>('[role="link"]');
-	if (!link) {
-		console.error('Could not find link element in conversation', index);
-		return;
-	}
+	let currentIndex = ((index % totalRows) + totalRows) % totalRows;
 
-	link.click();
+	for (let attempt = 0; attempt < totalRows; attempt++) {
+		const conversation = rows[currentIndex];
+
+		if (conversation) {
+			const link = conversation.querySelector<HTMLElement>('[role="link"]');
+			if (link) {
+				link.click();
+				return;
+			}
+		}
+
+		// Skip non-link rows (e.g. ads, "show more") by advancing in the direction
+		if (direction === 0) {
+			break;
+		}
+
+		const wrappedIndex = (currentIndex + direction) % totalRows;
+		currentIndex = (wrappedIndex + totalRows) % totalRows;
+	}
 }
 
 function selectedConversationIndex(offset = 0): number {

--- a/source/browser/conversation-list.ts
+++ b/source/browser/conversation-list.ts
@@ -326,6 +326,7 @@ function countUnread(mutationsList: MutationRecord[]): void {
 		// Send a notification
 		ipc.callMain('notification', {
 			id: conversationId,
+			href,
 			title: titleText,
 			body: bodyText ?? 'New message',
 			icon: imgUrl,

--- a/source/index.ts
+++ b/source/index.ts
@@ -847,10 +847,11 @@ if (is.linux) {
 }
 
 const notifications = new Map();
+const notificationHrefs = new Map<number, string>();
 
 ipc.answerRenderer(
 	'notification',
-	({id, title, body, icon, silent}: {id: number; title: string; body: string; icon: string; silent: boolean}) => {
+	({id, href, title, body, icon, silent}: {id: number; href?: string; title: string; body: string; icon: string; silent: boolean}) => {
 		// Don't send notifications when the window is focused
 		if (mainWindow.isFocused()) {
 			return;
@@ -860,6 +861,7 @@ ipc.answerRenderer(
 		if (notifications.has(id)) {
 			notifications.get(id).close();
 			notifications.delete(id);
+			notificationHrefs.delete(id);
 		}
 
 		// Skip notification if notifications are muted
@@ -876,24 +878,38 @@ ipc.answerRenderer(
 		});
 
 		notifications.set(id, notification);
+		if (href) {
+			notificationHrefs.set(id, href);
+		}
 
 		notification.on('click', () => {
 			showAndFocusWindow(mainWindow);
-			sendAction('notification-callback', {callbackName: 'onclick', id});
+			sendAction('notification-callback', {
+				callbackName: 'onclick',
+				id,
+				href: notificationHrefs.get(id),
+			});
 
 			notifications.delete(id);
+			notificationHrefs.delete(id);
 		});
 
 		notification.on('reply', (_event, reply: string) => {
-			// We use onclick event used by messenger to go to the right convo
-			sendBackgroundAction('notification-reply-callback', {callbackName: 'onclick', id, reply});
+			sendBackgroundAction('notification-reply-callback', {
+				callbackName: 'onclick',
+				id,
+				reply,
+				href: notificationHrefs.get(id),
+			});
 
 			notifications.delete(id);
+			notificationHrefs.delete(id);
 		});
 
 		notification.on('close', () => {
 			sendBackgroundAction('notification-callback', {callbackName: 'onclose', id});
 			notifications.delete(id);
+			notificationHrefs.delete(id);
 		});
 
 		if (!silent) {

--- a/source/index.ts
+++ b/source/index.ts
@@ -30,6 +30,7 @@ import tray from './tray';
 import {
 	sendAction,
 	sendBackgroundAction,
+	showAndFocusWindow,
 	messengerDomain,
 	stripTrackingFromUrl,
 } from './util';
@@ -118,11 +119,7 @@ if (!app.requestSingleInstanceLock()) {
 
 app.on('second-instance', () => {
 	if (mainWindow) {
-		if (mainWindow.isMinimized()) {
-			mainWindow.restore();
-		}
-
-		mainWindow.show();
+		showAndFocusWindow(mainWindow);
 	}
 });
 
@@ -881,6 +878,7 @@ ipc.answerRenderer(
 		notifications.set(id, notification);
 
 		notification.on('click', () => {
+			showAndFocusWindow(mainWindow);
 			sendAction('notification-callback', {callbackName: 'onclick', id});
 
 			notifications.delete(id);

--- a/source/notification-event.d.ts
+++ b/source/notification-event.d.ts
@@ -1,5 +1,6 @@
 type NotificationEvent = {
 	id: number;
+	href?: string;
 	title: string;
 	body: string;
 	icon: string;

--- a/source/util.ts
+++ b/source/util.ts
@@ -28,6 +28,27 @@ export async function sendBackgroundAction<T, ReturnValue>(action: string, argum
 	return ipcMain.callRenderer<T, ReturnValue>(getWindow(), action, arguments_);
 }
 
+export function showAndFocusWindow(win: BrowserWindow): void {
+	if (!win || win.isDestroyed()) {
+		return;
+	}
+
+	if (win.isMinimized()) {
+		win.restore();
+	}
+
+	if (!win.isVisible()) {
+		win.show();
+	}
+
+	if (is.windows) {
+		win.setAlwaysOnTop(true);
+		win.setAlwaysOnTop(false);
+	}
+
+	win.focus();
+}
+
 export function showRestartDialog(message: string): void {
 	const buttonIndex = dialog.showMessageBoxSync(
 		getWindow(),


### PR DESCRIPTION
- Fix Control+Tab / Control+Shift+Tab creating new conversations instead of navigating (prevent Facebook's key handler from firing)\n- Fix Cannot read properties of null (reading 'click') by properly null-checking the link element\n- Navigate to the correct conversation when clicking a toast notification (pass conversation href through notification system)\n- Skip non-link rows (ads, loading indicators) when cycling through conversations