### PR TITLE
Fix unresponsive and cut-off buttons in story and media viewer on macOS

### DIFF
--- a/css/browser.css
+++ b/css/browser.css
@@ -252,3 +252,21 @@ body.show-message-buttons .s8sjc6am.z6erz7xo.alzwoclg.jcxyg2ei.i85zmo3j.b0ur3jhr
 body.show-message-buttons .cgu29s5g.alzwoclg.oo5upp5e {
 	margin-left: 15px !important;
 }
+
+/* Story & media viewer controls */
+[role='dialog'] button,
+[role='dialog'] [role='button'],
+[role='dialog'] a,
+[role='dialog'] [aria-label],
+[role='dialog'] svg,
+[data-pagelet*='Story'] [role='button'],
+[data-pagelet*='Story'] [aria-label],
+[data-pagelet*='Story'] button,
+[data-pagelet*='Story'] a,
+[data-pagelet*='MediaViewer'] [role='button'],
+[data-pagelet*='MediaViewer'] [aria-label],
+[data-pagelet*='MediaViewer'] button,
+[data-pagelet*='MediaViewer'] a {
+	-webkit-app-region: no-drag !important;
+	pointer-events: auto !important;
+}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 		"lint": "npm run lint:xo && npm run lint:stylelint",
 		"test:tsc": "npm run build",
 		"test": "npm run test:tsc && npm run lint",
+		"dev": "npm start",
 		"start": "tsc && electron .",
 		"build": "tsc",
 		"dist:linux": "electron-builder --linux",

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -867,6 +867,36 @@ function observeMessengerLayout(): void {
 	observer.observe(document.body, {childList: true, subtree: true});
 }
 
+function observeMediaViewer(): void {
+	if (!is.macos) {
+		return;
+	}
+
+	const adjustTopControls = () => {
+		const controls = document.querySelectorAll<HTMLElement>('[role="button"], button, [aria-label], svg');
+		for (const control of controls) {
+			const rect = control.getBoundingClientRect();
+			// If an interactive control is at the very top edge (y >= 0 && y < 20) and not in normal chat header
+			if (rect.top >= 0 && rect.top < 20 && rect.height > 0 && rect.width > 0) {
+				if (control.closest('[role="navigation"]') ?? control.closest('[role="main"] > div:first-child')) {
+					continue;
+				}
+
+				const targetElement = (control.tagName.toLowerCase() === 'svg' ? control.parentElement : control)!;
+				targetElement.style.setProperty('margin-top', '24px', 'important');
+				targetElement.style.setProperty('-webkit-app-region', 'no-drag', 'important');
+				targetElement.style.setProperty('pointer-events', 'auto', 'important');
+			}
+		}
+	};
+
+	const observer = new MutationObserver(() => {
+		adjustTopControls();
+	});
+
+	observer.observe(document.body, {childList: true, subtree: true});
+}
+
 // Inject a global style node to maintain custom appearance after conversation change or startup
 document.addEventListener('DOMContentLoaded', async () => {
 	const style = document.createElement('style');
@@ -909,6 +939,9 @@ document.addEventListener('DOMContentLoaded', async () => {
 	// Hook broken dark mode observer
 	observeThemeBugs();
 
+	// Hook media viewer top controls observer on macOS
+	observeMediaViewer();
+
 	// Inject a transparent drag bar at the top of the window on macOS.
 	// This is needed because Facebook's JS event handlers on child elements
 	// prevent -webkit-app-region: drag from working when the window is focused.
@@ -928,9 +961,56 @@ document.addEventListener('DOMContentLoaded', async () => {
 		dragBar.style.setProperty('-webkit-app-region', 'drag');
 		document.body.append(dragBar);
 
-		const interactiveSelector = 'button, a[href], input, select, textarea, [role="button"], [role="link"], [role="search"], [contenteditable="true"]';
+		const isMediaOverlayActive = () => {
+			const {pathname} = window.location;
+			return pathname.startsWith('/stories')
+				|| pathname.startsWith('/photo')
+				|| pathname.includes('/photos/')
+				|| document.querySelector('[role="dialog"]') !== null
+				|| document.querySelector('[data-pagelet*="Story"]') !== null
+				|| document.querySelector('[data-pagelet*="MediaViewer"]') !== null
+				|| document.querySelector('[aria-label*="Story"]') !== null;
+		};
 
-		// Debounce mousemove to reduce CPU usage - only process every 100ms
+		const interactiveSelector = 'button, a, input, select, textarea, [role="button"], [role="link"], [role="search"], [role="tab"], [role="menuitem"], [contenteditable="true"], [tabindex], [aria-label], svg, path, i, [data-visualcompletion]';
+
+		const updateDragBar = (clientX: number, clientY: number) => {
+			if (clientY >= dragBarHeight) {
+				dragBar.style.pointerEvents = '';
+				return;
+			}
+
+			if (isMediaOverlayActive()) {
+				dragBar.style.pointerEvents = 'none';
+				return;
+			}
+
+			// Temporarily hide drag bar to find what's underneath
+			dragBar.style.pointerEvents = 'none';
+			const target = document.elementFromPoint(clientX, clientY);
+
+			if (target?.closest(interactiveSelector)) {
+				// Over an interactive element - keep drag bar transparent for clicks
+				return;
+			}
+
+			// Over empty space - re-enable drag bar for window dragging
+			dragBar.style.pointerEvents = '';
+		};
+
+		// Immediate check on pointerdown/mousedown so clicks are never swallowed by debouncing
+		document.addEventListener('pointerdown', (event: PointerEvent) => {
+			if (event.clientY < dragBarHeight) {
+				updateDragBar(event.clientX, event.clientY);
+			}
+		}, {capture: true, passive: true});
+
+		document.addEventListener('mousedown', (event: MouseEvent) => {
+			if (event.clientY < dragBarHeight) {
+				updateDragBar(event.clientX, event.clientY);
+			}
+		}, {capture: true, passive: true});
+
 		let debounceTimer: ReturnType<typeof setTimeout> | undefined;
 		let lastMouseX = 0;
 		let lastMouseY = 0;
@@ -938,30 +1018,19 @@ document.addEventListener('DOMContentLoaded', async () => {
 			lastMouseX = event.clientX;
 			lastMouseY = event.clientY;
 
+			if (lastMouseY < dragBarHeight) {
+				updateDragBar(lastMouseX, lastMouseY);
+				return;
+			}
+
 			if (debounceTimer) {
 				return;
 			}
 
 			debounceTimer = setTimeout(() => {
 				debounceTimer = undefined;
-
-				if (lastMouseY >= dragBarHeight) {
-					dragBar.style.pointerEvents = '';
-					return;
-				}
-
-				// Temporarily hide drag bar to find what's underneath
-				dragBar.style.pointerEvents = 'none';
-				const target = document.elementFromPoint(lastMouseX, lastMouseY);
-
-				if (target?.closest(interactiveSelector)) {
-					// Over an interactive element - keep drag bar transparent for clicks
-					return;
-				}
-
-				// Over empty space - re-enable drag bar for window dragging
-				dragBar.style.pointerEvents = '';
-			}, 100);
+				updateDragBar(lastMouseX, lastMouseY);
+			}, 50);
 		}, {passive: true});
 	}
 });
@@ -1061,6 +1130,10 @@ function isInternalUrl(url: URL): boolean {
 		return true;
 	}
 
+	if (url.pathname.startsWith('/stories')) {
+		return true;
+	}
+
 	if (url.pathname.startsWith('/login')) {
 		return true;
 	}
@@ -1090,6 +1163,7 @@ document.addEventListener('click', (event: MouseEvent) => {
 	const currentUrl = new URL(window.location.href);
 	const isFacebookDomain = currentUrl.hostname.endsWith('.facebook.com') || currentUrl.hostname === 'www.facebook.com' || currentUrl.hostname === 'web.facebook.com';
 	const isMessagesPage = isFacebookDomain && currentUrl.pathname.startsWith('/messages');
+	const isStoriesPage = isFacebookDomain && currentUrl.pathname.startsWith('/stories');
 	const isLoginPage = isFacebookDomain && (
 		currentUrl.pathname.startsWith('/login')
 		|| currentUrl.pathname.startsWith('/checkpoint')
@@ -1098,7 +1172,7 @@ document.addEventListener('click', (event: MouseEvent) => {
 		|| currentUrl.pathname === '/'
 	);
 
-	if (!isMessagesPage && !isLoginPage) {
+	if (!isMessagesPage && !isLoginPage && !isStoriesPage) {
 		return;
 	}
 


### PR DESCRIPTION
## Description
Fixes an issue where action buttons (Close \`X\`, Download icon, Share/Forward icon) were unresponsive to clicks or physically cut in half/clipped off by the top edge of the window in the Story Viewer and full-screen Media/Photo Viewer (especially for portrait / vertical mobile photos) on macOS.

### Root Causes
1. **macOS Frameless Window Header Inset**: On macOS with \`titleBarStyle: 'hiddenInset'\`, the content area starts at \`y = 0\`. In Facebook's full-screen photo theater and story viewer, top action buttons are positioned at \`top: 0px\`. For vertical (portrait 3:4 / 9:16) mobile photos that fill 100% viewport height, the top half of the Download and Share SVG icons were physically clipped off by the top window border.
2. **Transparent Drag Bar Interception**: A 24px transparent drag bar (\`#caprine-drag-bar\`, \`z-index: 99999\`) with \`-webkit-app-region: drag\` handles window dragging on macOS. In Electron, \`-webkit-app-region: drag\` intercepts mouse clicks before they reach underlying web elements in the top 24px zone.
3. **Generic Portal DOM Mounting**: Facebook renders chat photo lightboxes in generic portals without standard \`role="dialog"\` or \`data-pagelet\` attributes, bypassing static CSS container rules.

### Changes
- **Universal Top Control Observer (\`observeMediaViewer\`)**: Added a dynamic \`MutationObserver\` in \`source/browser.ts\` that detects top-edge action controls (\`rect.top < 20px\`) across photo overlays and story viewports, shifting them down by \`24px\` (\`margin-top: 24px !important\`) and ensuring they are fully visible, aligned with macOS traffic lights, and interactive.
- **Media Overlay Detection & Drag Bar Suppression (\`isMediaOverlayActive\`)**: Deactivates \`caprine-drag-bar\` (\`pointer-events: none\`) whenever a photo lightbox, story, or modal dialog is active, allowing 100% of clicks to pass through.
- **Immediate Hit-Testing & Expanded Selectors**: Added immediate \`pointerdown\`/\`mousedown\` hit-testing for \`caprine-drag-bar\` and expanded \`interactiveSelector\` to cover all SVG icons, path elements, and aria-labels.
- **Whitelisted \`/stories\` and \`/photo\`**: Added internal route handling in \`source/browser.ts\`.
- **CSS Rules**: Enforced \`-webkit-app-region: no-drag !important; pointer-events: auto !important;\` for all controls in dialogs, stories, and media viewers in \`css/browser.css\`.

### Verification & Testing
- [x] Tested Story Viewer: Close (X), Download, and Share buttons are fully visible and clickable.
- [x] Tested Vertical Mobile Photos (3:4, 4:5, 9:16): Action buttons are shifted down below the window frame, rendered completely, and responsive.
- [x] Tested macOS Window Dragging: Empty top-bar areas outside interactive buttons remain draggable.
- [x] \`npm run test\` passed (TypeScript compilation, XO linter, Stylelint: 0 errors).
- [x] Tested macOS Apple Silicon build (\`Caprine-2.61.24-arm64.dmg\`).